### PR TITLE
Fix policycoreutils requires in selinux_requires macro

### DIFF
--- a/macros.selinux-policy
+++ b/macros.selinux-policy
@@ -38,7 +38,7 @@ BuildRequires: selinux-policy-devel \
 Requires(post): selinux-policy-base >= %{_selinux_policy_version} \
 Requires(post): libselinux-utils \
 Requires(post): policycoreutils \
-%if 0%{?fedora} \
+%if 0%{?fedora} || 0%{?rhel} >= 8\
 Requires(post): policycoreutils-python-utils \
 %else \
 Requires(post): policycoreutils-python \


### PR DESCRIPTION
policycoreutils-python changed to policycoreutils-python-utils in RHEL 8
(same as in Fedora).