### PR TITLE
Macros: don't call semodule for not-loaded policy

### DIFF
--- a/macros.selinux-policy
+++ b/macros.selinux-policy
@@ -133,7 +133,7 @@ for boolean in %*; do \
 done; \
 if %{_sbindir}/selinuxenabled && [ "${SELINUXTYPE}" = "${_policytype}" ]; then \
     /bin/echo -e "$semanage_import" | %{_sbindir}/semanage import -S "${_policytype}" \
-else \
+elif test -d /usr/share/selinux/"${_policytype}"/base.lst; then \
     /bin/echo -e "$semanage_import" | %{_sbindir}/semanage import -S "${_policytype}" -N \
 fi \
 %{nil}
@@ -158,7 +158,7 @@ for boolean in %*; do \
 done; \
 if %{_sbindir}/selinuxenabled && [ "${SELINUXTYPE}" = "${_policytype}" ]; then \
     /bin/echo -e "$semanage_import" | %{_sbindir}/semanage import -S "${_policytype}" \
-else \
+elif test -d /usr/share/selinux/"${_policytype}"/base.lst; then \
     /bin/echo -e "$semanage_import" | %{_sbindir}/semanage import -S "${_policytype}" -N \
 fi \
 %{nil}

--- a/macros.selinux-policy
+++ b/macros.selinux-policy
@@ -134,7 +134,7 @@ done; \
 if %{_sbindir}/selinuxenabled && [ "${SELINUXTYPE}" = "${_policytype}" ]; then \
     /bin/echo -e "$semanage_import" | %{_sbindir}/semanage import -S "${_policytype}" \
 else \
-    /bin/echo -e "$semanage_import" | %{_sbindir}/semanage import -S "${_policytype} -N" \
+    /bin/echo -e "$semanage_import" | %{_sbindir}/semanage import -S "${_policytype}" -N \
 fi \
 %{nil}
 
@@ -159,6 +159,6 @@ done; \
 if %{_sbindir}/selinuxenabled && [ "${SELINUXTYPE}" = "${_policytype}" ]; then \
     /bin/echo -e "$semanage_import" | %{_sbindir}/semanage import -S "${_policytype}" \
 else \
-    /bin/echo -e "$semanage_import" | %{_sbindir}/semanage import -S "${_policytype} -N" \
+    /bin/echo -e "$semanage_import" | %{_sbindir}/semanage import -S "${_policytype}" -N \
 fi \
 %{nil}

--- a/macros.selinux-policy
+++ b/macros.selinux-policy
@@ -52,9 +52,9 @@ _policytype=%{-s*} \
 if [ -z "${_policytype}" ]; then \
   _policytype="targeted" \
 fi \
-%{_sbindir}/semodule -n -s ${_policytype} -X %{!-p:200}%{-p*} -i %* \
-if %{_sbindir}/selinuxenabled && [ "${SELINUXTYPE}" = "${_policytype}" ]; then \
-  %{_sbindir}/load_policy \
+if [ "${SELINUXTYPE}" = "${_policytype}" ]; then \
+  %{_sbindir}/semodule -n -s ${_policytype} -X %{!-p:200}%{-p*} -i %* \
+  %{_sbindir}/selinuxenabled && %{_sbindir}/load_policy \
 fi \
 %{nil}
 
@@ -66,9 +66,9 @@ if [ -z "${_policytype}" ]; then \
   _policytype="targeted" \
 fi \
 if [ $1 -eq 0 ]; then \
-  %{_sbindir}/semodule -n -X %{!-p:200}%{-p*} -s ${_policytype} -r %* &> /dev/null || : \
-  if %{_sbindir}/selinuxenabled && [ "${SELINUXTYPE}" = "${_policytype}" ]; then \
-    %{_sbindir}/load_policy \
+  if [ "${SELINUXTYPE}" = "${_policytype}" ]; then \
+    %{_sbindir}/semodule -n -X %{!-p:200}%{-p*} -s ${_policytype} -r %* &> /dev/null || : \
+    %{_sbindir}/selinuxenabled && %{_sbindir}/load_policy \
   fi \
 fi \
 %{nil}


### PR DESCRIPTION
We'd like to do stuff like:

  for selinuxvariant in targeted mls; do
    %selinux_modules_install -s $selinuxvariant ...
    %selinux_set_booleans    -s $selinuxvariant ...
  done

But the 'semodule' fails for the 'mls' variant if we run
'targeted'.