### PR TITLE
Check if SELinux store exists before boolean is set/unset to avoid tracebacks

### DIFF
--- a/macros.selinux-policy
+++ b/macros.selinux-policy
@@ -133,7 +133,7 @@ if [ -d "%{_selinux_store_policy_path}" ]; then \
           /bin/echo "boolean -m --$boolean_default_value $boolean_name" >> %_file_custom_defined_booleans \
       fi \
   done; \
-  if %{_sbindir}/selinuxenabled && [ "${SELINUXTYPE}" = "${_policytype}" ]; then \
+  if $(ls %{_sysconfdir}/selinux/${_policytype}/policy/policy.* &>/dev/null) && [ "${SELINUXTYPE}" = "${_policytype}" ]; then \
       /bin/echo -e "$semanage_import" | %{_sbindir}/semanage import -S "${_policytype}" \
   elif test -d /usr/share/selinux/"${_policytype}"/base.lst; then \
       /bin/echo -e "$semanage_import" | %{_sbindir}/semanage import -S "${_policytype}" -N \
@@ -160,7 +160,7 @@ if [ -d "%{_selinux_store_policy_path}" ]; then \
           fi \
       fi \
   done; \
-  if %{_sbindir}/selinuxenabled && [ "${SELINUXTYPE}" = "${_policytype}" ]; then \
+  if $(ls %{_sysconfdir}/selinux/${_policytype}/policy/policy.* &>/dev/null) && [ "${SELINUXTYPE}" = "${_policytype}" ]; then \
       /bin/echo -e "$semanage_import" | %{_sbindir}/semanage import -S "${_policytype}" \
   elif test -d /usr/share/selinux/"${_policytype}"/base.lst; then \
       /bin/echo -e "$semanage_import" | %{_sbindir}/semanage import -S "${_policytype}" -N \


### PR DESCRIPTION
This PR is checking if SELinux store exists on filesystem before SELinux tooling change the value of the boolean to avoid tracebacks in semanage. 