### PR TITLE
Fix SELinux modules not installing in chroots.

### DIFF
--- a/macros.selinux-policy
+++ b/macros.selinux-policy
@@ -54,7 +54,7 @@ if [ -z "${_policytype}" ]; then \
   _policytype="targeted" \
 fi \
 if [ "${SELINUXTYPE}" = "${_policytype}" ]; then \
-  %{_sbindir}/semodule -n -s ${_policytype} -X %{!-p:200}%{-p*} -i %* \
+  %{_sbindir}/semodule -n -s ${_policytype} -X %{!-p:200}%{-p*} -i %* || : \
   %{_sbindir}/selinuxenabled && %{_sbindir}/load_policy || : \
 fi \
 %{nil}


### PR DESCRIPTION
Using `%selinux_modules_install` fails anaconda builds when generating ISOs containing RPM packages using this macro.
SELinux modules cannot install in a chroot, and so we need to ignore this during these cases.
Relates to [Bugzilla #1665643](https://bugzilla.redhat.com/show_bug.cgi?id=1665643).

Technically, [RPM scriplets](https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/) cannot have a non-zero exit status, but anaconda has stricter guidelines, failing scriptlets immediately when a non-zero exit status occurs. This prevents RPMs using the `%selinux_modules_install` macro from installing in an ISO, failing the build. 

There needs to be a `|| : ` after the first `%{_sbindir}/semodule...}` statement in order for anaconda to continue to the next line. 

Closes #10 